### PR TITLE
Use String#each_line on ruby 1.9.2 compatability

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -209,7 +209,11 @@ class SystemUniversal
     if src.respond_to? 'read'
       while((buf = src.read(8192))); dst << buf; end
     else
-      src.each{|buf| dst << buf}
+      if src.respond_to?(:each_line)
+        src.each_line{|buf| dst << buf}
+      else
+        src.each{|buf| dst << buf}
+      end
     end
   end
 


### PR DESCRIPTION
Ruby 1.9.x does not have String#each anymore, this adds a simple check to use each_line when that is available.
