### PR TITLE
work around the syck/psych confusion yaml brings to ruby 1.9.2 by trying to load psych before yaml

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -174,6 +174,10 @@ class SystemUniversal
     <<-program
       PIPE = STDOUT.dup
       begin
+        begin
+          require 'psych'
+        rescue LoadError
+        end
         require 'yaml'
 
         config = YAML.load(IO.read('#{ config }'))


### PR DESCRIPTION
On Windows 7, RubyInstaller 1.9.2p290 I get 

wtf?
o:↕NoMethodError        :       mesgIu:↨NameError::messageZundefined method `each' for #<Syck::PrivateType:0x210aa58 @type_id="null", @value="">♠:♠EF:bt[♠I"oC:/Users/damphyr/AppData/Local/Temp/systemu_DEV_2168_4076_0.6119730099144441_1/program:15:in`<main>'♠:encoding"♂IBM437:       name:   each:   args[

Ignoring the weird encoding there I chased it down to the temp child program. Preloading 'psych' works
