### PR TITLE
Eliminate use Marshall/YAML in child_program

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -297,7 +297,7 @@ BEGIN {
 
 # discover full path to this ruby executable
 #
-  c = Config::CONFIG
+  c = RbConfig::CONFIG
   bindir = c["bindir"] || c['BINDIR']
   ruby_install_name = c['ruby_install_name'] || c['RUBY_INSTALL_NAME'] || 'ruby'
   ruby_ext = c['EXEEXT'] || ''


### PR DESCRIPTION
Tested on Win7/1.9.2 for which the 2.3.0 version does not work due to encoding problems when marshaling.

This also spares us two disk writes which can only be a good thing.