### PR TITLE
Switch deprecated 'Config' over to 'RbConfig'

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -25,7 +25,7 @@ class SystemUniversal
   @pid = Process.pid
   @turd = ENV['SYSTEMU_TURD']
 
-  c = ::Config::CONFIG
+  c = ::RbConfig::CONFIG
   ruby = File.join(c['bindir'], c['ruby_install_name']) << c['EXEEXT']
   @ruby = if system('%s -e 42' % ruby)
     ruby


### PR DESCRIPTION
Fixes this deprecation warning:

```
ruby/1.9.1/gems/systemu-2.3.0/lib/systemu.rb:28: Use RbConfig instead of obsolete and deprecated Config.
```

Tested on Ruby 1.9.3-preview1 and 1.8.7-p352.
