### PR TITLE
fix Ruby 1.9 encoding related issue: make sure buf has correct encoding.

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -203,7 +203,7 @@ class SystemUniversal
 
   def relay srcdst
     src, dst, ignored = srcdst.to_a.first
-    if src.respond_to? 'read'
+    if src.respond_to? 'read' and not (src.respond_to? 'external_encoding' and src.external_encoding != 'ASCII-8BIT')
       while((buf = src.read(8192))); dst << buf; end
     else
       if src.respond_to?(:each_line)


### PR DESCRIPTION
IO#read() always returns ASCII-8BIT string on Ruby 1.9, regardless of external_encoding of IO object.
Without this fix, Object.systemu returns ASCII-8BIT string as 'stdout' and 'stderr', but it is unnatural on Ruby 1.9.
