### PR TITLE
pass pid to RubyProcess::RubyStatus.new_process_status

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -173,7 +173,7 @@ class SystemUniversal
   def child_program config
     <<-program
       # encoding: utf-8
-       
+
       PIPE = STDOUT.dup
       begin
         config = Marshal.load(IO.read('#{ config }'))
@@ -274,8 +274,11 @@ if defined? JRUBY_VERSION
       end
 
       exit_code = process.wait_for
+      field = process.get_class.get_declared_field("pid")
+      field.set_accessible(true)
+      pid = field.get(process)
       [
-        RubyProcess::RubyStatus.new_process_status(JRuby.runtime, exit_code),
+        RubyProcess::RubyStatus.new_process_status(JRuby.runtime, exit_code, pid),
         stdout.join,
         stderr.join
       ]


### PR DESCRIPTION
I'd look to use systemu as a dependency for bahia. However jruby doesn't work as explained in #9. I've observed the same bug in jruby 1.6.7 for both ruby 1.8 and 1.9. I've implemented the solution explained in #9 and it's working for me locally. For an example of this bug, see the CI output in http://travis-ci.org/#!/cldwalker/tag/jobs/840108 .
