### PR TITLE
Escape apostrophes in code output

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -171,6 +171,7 @@ class SystemUniversal
   end
 
   def child_program config
+    config = config.gsub(/'/, "\\\\'")
     <<-program
       # encoding: utf-8
 


### PR DESCRIPTION
Systems with apostrophes in them, like "Ben's Macbook Pro", create invalid code based on the names that come back from `Dir.tmpdir`. A simple one-line fix that I'm not quite sure how to write a test for, but it works with the above machine name.
