### PR TITLE
Add :env_override option to replace environment.

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-NAME
+NAME 
 
   systemu
 


### PR DESCRIPTION
The current `:env` option adds to the current environment, or alters
existing variables, but passes all environment variables in the calling
process through to the called process.

For greater control, the `:env_override` option allows the entire
environment of the subprocess to be specified.

When both `:env_override` and `:env` are passed, the `:env_override` is
applied first, and then the entries of `:env`, if any, are merged.

Why not just set an unwanted environment variable to `nil` in `:env`?
Because the key will still be present in the environment with an empty
value, and some programs that only check for the existence of an
environment variable will behave differently.

Why not just call `ENV.replace` before calling `systemu`? Because `systemu`
launches Ruby, and Ruby might require a variable like `LD_LIBRARY_PATH` to
be set in order to run, but the user may not want that to be passed through
to the called process.
