### PR TITLE
Optimize gem loading time

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -31,10 +31,10 @@ class SystemUniversal
 
   c = begin; ::RbConfig::CONFIG; rescue NameError; ::Config::CONFIG; end
   ruby = File.join(c['bindir'], c['ruby_install_name']) << c['EXEEXT']
-  @ruby = if system('%s --version' % ruby)
+  @ruby = if `#{ruby} --version`
     ruby
   else
-    system('%s --version' % 'ruby') ? 'ruby' : warn('no ruby in PATH/CONFIG')
+    `ruby --version` ? 'ruby' : warn('no ruby in PATH/CONFIG')
   end
 
   class << SystemUniversal

--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -31,10 +31,10 @@ class SystemUniversal
 
   c = begin; ::RbConfig::CONFIG; rescue NameError; ::Config::CONFIG; end
   ruby = File.join(c['bindir'], c['ruby_install_name']) << c['EXEEXT']
-  @ruby = if system('%s -e 42' % ruby)
+  @ruby = if system('%s --version' % ruby)
     ruby
   else
-    system('%s -e 42' % 'ruby') ? 'ruby' : warn('no ruby in PATH/CONFIG')
+    system('%s --version' % 'ruby') ? 'ruby' : warn('no ruby in PATH/CONFIG')
   end
 
   class << SystemUniversal


### PR DESCRIPTION
Took about 0.5 seconds to load this gem due to a system call that checks if ruby is installed. Instead of loading the entire ruby environment to verify the existence of a ruby executable, I had it check the version. I couldn't get your tests to run, but I think this replacement should be sufficient.
