### PR TITLE
Fix problem when ruby exe path has spaces

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -35,10 +35,10 @@ class SystemUniversal
 
     c = begin; ::RbConfig::CONFIG; rescue NameError; ::Config::CONFIG; end
     ruby = File.join(c['bindir'], c['ruby_install_name']) << c['EXEEXT']
-    @ruby = if system('%s -e 42' % ruby)
+    @ruby = if system(ruby, '-e', '42')
       ruby
     else
-      system('%s -e 42' % 'ruby') ? 'ruby' : warn('no ruby in PATH/CONFIG')
+      system('ruby', '-e', '42') ? 'ruby' : warn('no ruby in PATH/CONFIG')
     end
   end
 


### PR DESCRIPTION
On Windows, it's possible that the RbConfig path to the ruby executable might contain spaces (e.g. "C:/Program Files/foo/ruby.exe"). If that happens, systemu's previous method of checking to see if that was a valid ruby executable was unreliable. This commit allows full paths to executables to have spaces by switching to individual argument invocation of system(), instead of relying on system() to correctly parse a single string into executable + arguments.