### PR TITLE
When finding ruby, skip loading rubygems for the speed

### DIFF
--- a/lib/systemu.rb
+++ b/lib/systemu.rb
@@ -35,10 +35,10 @@ class SystemUniversal
 
     c = begin; ::RbConfig::CONFIG; rescue NameError; ::Config::CONFIG; end
     ruby = File.join(c['bindir'], c['ruby_install_name']) << c['EXEEXT']
-    @ruby = if system(ruby, '-e', '42')
+    @ruby = if system(ruby, '--disable-gems', '-e', '42')
       ruby
     else
-      system('ruby', '-e', '42') ? 'ruby' : warn('no ruby in PATH/CONFIG')
+      system('ruby', '--disable-gems', '-e', '42') ? 'ruby' : warn('no ruby in PATH/CONFIG')
     end
   end
 


### PR DESCRIPTION
Maybe this is yet another solution for #35.

Recent versions of ruby loads rubygems by default, which in some cases adds recognizable delay on simple `ruby -e` call, for instance when having thousands of gems installed in the system.

Here are results of `time` executing `ruby -e` with and without `--disable-gems` option on my machine (Ruby 2.5.0, Mac OSX).
Not very much significant, but still we can see a little bit of improvement.

```
% time ruby -e 42
ruby -e 42  0.08s user 0.04s system 85% cpu 0.138 total
% time ruby -e 42
ruby -e 42  0.08s user 0.03s system 94% cpu 0.118 total
% time ruby -e 42
ruby -e 42  0.07s user 0.03s system 83% cpu 0.124 total
% time ruby -e 42
ruby -e 42  0.07s user 0.04s system 94% cpu 0.112 total
% time ruby -e 42
ruby -e 42  0.07s user 0.03s system 93% cpu 0.109 total
```

```
% time ruby --disable-gems -e 42
ruby --disable-gems -e 42  0.03s user 0.03s system 80% cpu 0.075 total
% time ruby --disable-gems -e 42
ruby --disable-gems -e 42  0.03s user 0.03s system 92% cpu 0.066 total
% time ruby --disable-gems -e 42
ruby --disable-gems -e 42  0.03s user 0.03s system 92% cpu 0.067 total
% time ruby --disable-gems -e 42
ruby --disable-gems -e 42  0.03s user 0.03s system 81% cpu 0.071 total
% time ruby --disable-gems -e 42
ruby --disable-gems -e 42  0.03s user 0.03s system 92% cpu 0.067 total
```