### PR TITLE
Attempt to enable Ruby 3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -297,7 +297,7 @@ BEGIN {
 
 # discover full path to this ruby executable
 #
-  c = Config::CONFIG
+  c = ::RbConfig::CONFIG
   bindir = c["bindir"] || c['BINDIR']
   ruby_install_name = c['ruby_install_name'] || c['RUBY_INSTALL_NAME'] || 'ruby'
   ruby_ext = c['EXEEXT'] || ''

--- a/test/systemu_test.rb
+++ b/test/systemu_test.rb
@@ -31,6 +31,21 @@ Testing SystemU do
     end
   end
 
+  testing 'invoke systemu with a block' do
+    res = systemu("sleep 0.1") { puts('Waiting') }
+    assert { res[1].instance_of?(String) }
+    assert { res[2].instance_of?(String) }
+    res = res[0]
+    assert { (res & 0xFFFF) == 0 }
+    assert { res == 0 }
+    assert { res.exited? }
+    assert { res.exitstatus == 0 }
+    assert { res.pid.instance_of?(Integer) }
+    assert { !res.signaled? }
+    assert { res.success? }
+    assert { res.to_i == 0 }
+    assert { res.to_s =~ /^pid \d+ exit 0$/ }
+  end
 end
 
 


### PR DESCRIPTION
This is an attempt at making systemu compatible with Ruby 3. Instead of trying to adjust the frozen `Process::Status` instance it introduces the `SystemU::Result` class which is a thin wrapper around the `Process::Status` instance.

To verify that the behaviour stays near constant an additonal testcase is being added too.